### PR TITLE
Fix: Replace local package dependency with remote GitHub URL

### DIFF
--- a/MLX Outil.xcodeproj/project.pbxproj
+++ b/MLX Outil.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 			packageReferences = (
 				8D758A832D5A57EF009AB6EC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 				0A60ACDE2E0E545F009DD9E6 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
-				0A60ACF02E0E6C93009DD9E6 /* XCLocalSwiftPackageReference "../MLX-Outil" */,
+				0A60ACF02E0E6C93009DD9E6 /* XCRemoteSwiftPackageReference "MLX-Outil" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 0AC155672CFBB30E00FBDD8E /* Products */;
@@ -521,17 +521,18 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		0A60ACF02E0E6C93009DD9E6 /* XCLocalSwiftPackageReference "../MLX-Outil" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = "../MLX-Outil";
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		0A60ACDE2E0E545F009DD9E6 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		0A60ACF02E0E6C93009DD9E6 /* XCRemoteSwiftPackageReference "MLX-Outil" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/rudrankriyam/MLX-Outil.git";
 			requirement = {
 				branch = main;
 				kind = branch;
@@ -560,6 +561,7 @@
 		};
 		0A60ACF12E0E6C93009DD9E6 /* MLXTools */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0A60ACF02E0E6C93009DD9E6 /* XCRemoteSwiftPackageReference "MLX-Outil" */;
 			productName = MLXTools;
 		};
 		8D758A842D5A57EF009AB6EC /* MarkdownUI */ = {

--- a/MLX Outil.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MLX Outil.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1fe762115e22548345ca3a60a5669a27c7b78bfcb860287d81fd6a7f79713b88",
+  "originHash" : "01348b48308373a20570336928e3a3fd8a2febf9983e3e23e7191f2b848bcf54",
   "pins" : [
     {
       "identity" : "gzipswift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "31c4dd39bcdc07eaa42a384bdc88ea599022b800",
         "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "mlx-outil",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rudrankriyam/MLX-Outil.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "aa120f6fb8f7ee08c798e01bd2f97e854940b73b"
       }
     },
     {


### PR DESCRIPTION
## Description
This PR fixes the issue where MLXTools package was referenced as a local dependency instead of using the proper GitHub URL, preventing external developers from building the project.

## Changes Made
- ✅ Replaced `XCLocalSwiftPackageReference` with `XCRemoteSwiftPackageReference`
- ✅ Added repository URL: `https://github.com/rudrankriyam/MLX-Outil.git`
- ✅ Set branch requirement to `main`
- ✅ Updated package product dependency to reference the remote package
- ✅ Removed local path reference `"../MLX-Outil"`

## Testing
- ✅ Swift package resolves dependencies successfully
- ✅ Swift package builds without errors
- ✅ All 8 MLXTools components remain accessible

## Impact
- 🎯 External developers can now clone and build the project
- 🎯 No more "missing package.swift file" errors
- 🎯 Improves project adoption and collaboration potential
- 🎯 Makes the project usable as a standalone example

## Files Changed
- `MLX Outil.xcodeproj/project.pbxproj` - Updated package dependency configuration

Fixes #8

## Before & After
**Before:** Local package reference preventing external usage
```
XCLocalSwiftPackageReference "../MLX-Outil"
```

**After:** Remote GitHub URL enabling external usage
```
XCRemoteSwiftPackageReference "https://github.com/rudrankriyam/MLX-Outil.git"
```